### PR TITLE
Typedoc building via actions

### DIFF
--- a/.github/workflows/build-typedoc.yml
+++ b/.github/workflows/build-typedoc.yml
@@ -1,0 +1,35 @@
+name: "typedoc"
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - run: npm ci
+      # Generate your TypeDoc documentation
+      - run: npx typedoc
+      # https://github.com/actions/upload-pages-artifact
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./docs  # This should be your TypeDoc "out" path.
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        # https://github.com/actions/deploy-pages
+        uses: actions/deploy-pages@v2

--- a/typedoc.json
+++ b/typedoc.json
@@ -4,7 +4,6 @@
   "includes": "./src/**/*.ts",
   "json": "./docs.json",
   "tsconfig": "./tsconfig.json",
-  "includes": "includes",
   "excludeExternals": true,
   "excludePrivate": true,
   "out": "./docs"

--- a/typedoc.json
+++ b/typedoc.json
@@ -6,5 +6,6 @@
   "tsconfig": "./tsconfig.json",
   "includes": "includes",
   "excludeExternals": true,
-  "excludePrivate": true
+  "excludePrivate": true,
+  "out": "./docs"
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -4,7 +4,7 @@
   "includes": "./src/**/*.ts",
   "json": "./docs.json",
   "tsconfig": "./tsconfig.json",
-  "includeDeclarations": "includes",
+  "includes": "includes",
   "excludeExternals": true,
   "excludePrivate": true
 }


### PR DESCRIPTION
As of now, the docs website is down (presumably because of the Railway free limits) , but this PR moves Typedoc building + deploying to Github actions and pages. No more downtime!!!

yay!