### PR TITLE
Fix incorrect UserRestriction Cloud API Endpoint

### DIFF
--- a/src/apis/cloud/userRestrictions/userRestrictions.ts
+++ b/src/apis/cloud/userRestrictions/userRestrictions.ts
@@ -71,7 +71,7 @@ export const restrictionForUser = createApiMethod(async <UniverseId extends Iden
   method: "GET",
   path: (
     placeId ? `/v2/universes/${universeId}/places/${placeId}/user-restrictions/${userId}`
-    : `/v2/universes/${universeId}/places/${placeId}/user-restrictions/${userId}`
+    : `/v2/universes/${universeId}/user-restrictions/${userId}`
   ),
   name: `restrictionForUser`,
 }))


### PR DESCRIPTION
Ternary used placeId when no placeId was provided.

closes: #18 